### PR TITLE
Harden suggested-authors endpoint against user enumeration

### DIFF
--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -297,7 +297,7 @@ class Rest_API {
 
 		// Require a minimum search length to prevent user enumeration.
 		// On large networks, require a longer search term to limit scope.
-		$min_length = wp_is_large_network( 'users' ) ? 5 : 2;
+		$min_length = \wp_is_large_network( 'users' ) ? 5 : 2;
 		if ( mb_strlen( $search ) < $min_length ) {
 			return new \WP_REST_Response( array(), 200 );
 		}

--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -297,7 +297,8 @@ class Rest_API {
 
 		// Require a minimum search length to prevent user enumeration.
 		// On large networks, require a longer search term to limit scope.
-		$min_length = function_exists( 'wp_is_large_network' ) && \wp_is_large_network( 'users' ) ? 5 : 2;
+		$is_large_network = function_exists( 'wp_is_large_network' ) && \wp_is_large_network( 'users' );
+		$min_length       = $is_large_network ? 5 : 2;
 		if ( mb_strlen( $search ) < $min_length ) {
 			return new \WP_REST_Response( array(), 200 );
 		}
@@ -306,12 +307,17 @@ class Rest_API {
 		$existing_ids   = Co_Authors::get_co_authors( $post_id );
 		$existing_ids[] = (int) $post->post_author;
 
+		// On large networks, restrict to indexed columns only for performance.
+		$search_columns = $is_large_network
+			? array( 'user_login', 'user_nicename' )
+			: array( 'user_login', 'user_nicename', 'display_name' );
+
 		$args = array(
 			'capability'     => array( 'edit_posts' ),
 			'number'         => 20,
 			'exclude'        => $existing_ids,
 			'search'         => '*' . $search . '*',
-			'search_columns' => array( 'user_login', 'user_nicename', 'display_name' ),
+			'search_columns' => $search_columns,
 		);
 
 		$users  = get_users( $args );

--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -297,7 +297,7 @@ class Rest_API {
 
 		// Require a minimum search length to prevent user enumeration.
 		// On large networks, require a longer search term to limit scope.
-		$min_length = \wp_is_large_network( 'users' ) ? 5 : 2;
+		$min_length = function_exists( 'wp_is_large_network' ) && \wp_is_large_network( 'users' ) ? 5 : 2;
 		if ( mb_strlen( $search ) < $min_length ) {
 			return new \WP_REST_Response( array(), 200 );
 		}

--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -296,8 +296,9 @@ class Rest_API {
 		$search  = (string) $request->get_param( 'search' );
 
 		// Require a minimum search length to prevent user enumeration.
-		// On large networks, a search term is always required.
-		if ( mb_strlen( $search ) < 2 ) {
+		// On large networks, require a longer search term to limit scope.
+		$min_length = wp_is_large_network( 'users' ) ? 5 : 2;
+		if ( mb_strlen( $search ) < $min_length ) {
 			return new \WP_REST_Response( array(), 200 );
 		}
 

--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -308,9 +308,14 @@ class Rest_API {
 		$existing_ids[] = (int) $post->post_author;
 
 		// On large networks, restrict to indexed columns only for performance.
+		// Allow email search only for users who can already view user details.
 		$search_columns = $is_large_network
 			? array( 'user_login', 'user_nicename' )
 			: array( 'user_login', 'user_nicename', 'display_name' );
+
+		if ( current_user_can( 'list_users' ) ) {
+			$search_columns[] = 'user_email';
+		}
 
 		$args = array(
 			'capability'     => array( 'edit_posts' ),

--- a/includes/class-map-rest-api.php
+++ b/includes/class-map-rest-api.php
@@ -292,8 +292,15 @@ class Rest_API {
 	 * @return \WP_REST_Response
 	 */
 	public static function get_suggested_authors( \WP_REST_Request $request ): \WP_REST_Response {
-		$post_id        = (int) $request->get_param( 'post_id' );
-		$search         = (string) $request->get_param( 'search' );
+		$post_id = (int) $request->get_param( 'post_id' );
+		$search  = (string) $request->get_param( 'search' );
+
+		// Require a minimum search length to prevent user enumeration.
+		// On large networks, a search term is always required.
+		if ( mb_strlen( $search ) < 2 ) {
+			return new \WP_REST_Response( array(), 200 );
+		}
+
 		$post           = get_post( $post_id );
 		$existing_ids   = Co_Authors::get_co_authors( $post_id );
 		$existing_ids[] = (int) $post->post_author;
@@ -302,12 +309,9 @@ class Rest_API {
 			'capability'     => array( 'edit_posts' ),
 			'number'         => 20,
 			'exclude'        => $existing_ids,
-			'search_columns' => array( 'user_login', 'user_nicename', 'user_email', 'display_name' ),
+			'search'         => '*' . $search . '*',
+			'search_columns' => array( 'user_login', 'user_nicename', 'display_name' ),
 		);
-
-		if ( '' !== $search ) {
-			$args['search'] = '*' . $search . '*';
-		}
 
 		$users  = get_users( $args );
 		$result = array();

--- a/tests/Test_Rest_API.php
+++ b/tests/Test_Rest_API.php
@@ -223,18 +223,19 @@ class Test_Rest_API extends WP_UnitTestCase {
 		$this->assertNotContains( $target, $ids );
 	}
 
-	public function test_suggested_authors_searches_by_email_for_editors(): void {
+	public function test_suggested_authors_searches_by_email_for_admins(): void {
+		$admin  = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$target = self::factory()->user->create(
 			array(
 				'role'         => 'author',
-				'user_email'   => 'editor-findable@example.com',
+				'user_email'   => 'admin-findable@example.com',
 				'display_name' => 'Hidden Name',
 			)
 		);
-		wp_set_current_user( $this->editor_id );
+		wp_set_current_user( $admin );
 
 		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
-		$request->set_param( 'search', 'editor-findable' );
+		$request->set_param( 'search', 'admin-findable' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$ids = array_column( $response->get_data(), 'id' );

--- a/tests/Test_Rest_API.php
+++ b/tests/Test_Rest_API.php
@@ -205,7 +205,7 @@ class Test_Rest_API extends WP_UnitTestCase {
 		$this->assertSame( array(), $response->get_data() );
 	}
 
-	public function test_suggested_authors_does_not_search_by_email(): void {
+	public function test_suggested_authors_does_not_search_by_email_for_authors(): void {
 		$target = self::factory()->user->create(
 			array(
 				'role'         => 'author',
@@ -221,6 +221,24 @@ class Test_Rest_API extends WP_UnitTestCase {
 
 		$ids = array_column( $response->get_data(), 'id' );
 		$this->assertNotContains( $target, $ids );
+	}
+
+	public function test_suggested_authors_searches_by_email_for_editors(): void {
+		$target = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'user_email'   => 'editor-findable@example.com',
+				'display_name' => 'Hidden Name',
+			)
+		);
+		wp_set_current_user( $this->editor_id );
+
+		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
+		$request->set_param( 'search', 'editor-findable' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$ids = array_column( $response->get_data(), 'id' );
+		$this->assertContains( $target, $ids );
 	}
 
 	public function test_suggested_authors_returns_results_for_valid_search(): void {

--- a/tests/Test_Rest_API.php
+++ b/tests/Test_Rest_API.php
@@ -180,6 +180,66 @@ class Test_Rest_API extends WP_UnitTestCase {
 		$this->assertSame( 403, $response->get_status() );
 	}
 
+	// -------------------------------------------------------------------------
+	// Suggested authors
+	// -------------------------------------------------------------------------
+
+	public function test_suggested_authors_returns_empty_for_short_search(): void {
+		wp_set_current_user( $this->author_id );
+
+		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
+		$request->set_param( 'search', 'a' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+	}
+
+	public function test_suggested_authors_returns_empty_for_empty_search(): void {
+		wp_set_current_user( $this->author_id );
+
+		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), $response->get_data() );
+	}
+
+	public function test_suggested_authors_does_not_search_by_email(): void {
+		$target = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'user_email'   => 'unique-test-email@example.com',
+				'display_name' => 'Test Target',
+			)
+		);
+		wp_set_current_user( $this->author_id );
+
+		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
+		$request->set_param( 'search', 'unique-test-email' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$ids = array_column( $response->get_data(), 'id' );
+		$this->assertNotContains( $target, $ids );
+	}
+
+	public function test_suggested_authors_returns_results_for_valid_search(): void {
+		$target = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'display_name' => 'Searchable Author',
+			)
+		);
+		wp_set_current_user( $this->author_id );
+
+		$request = new WP_REST_Request( 'GET', '/multi-author-posts/v1/posts/' . $this->post_id . '/suggested-authors' );
+		$request->set_param( 'search', 'Searchable' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$ids = array_column( $response->get_data(), 'id' );
+		$this->assertContains( $target, $ids );
+	}
+
 	public function test_editor_can_manage_co_authors_via_edit_others_posts(): void {
 		// An editor (who has edit_others_posts) can manage co-authors even
 		// though they are not the post author.


### PR DESCRIPTION
## Summary
- Enforces minimum search length of 2 characters server-side (client already enforced this, but the API did not)
- Removes `user_email` from search columns to prevent email address confirmation/enumeration
- Empty or short searches return empty results instead of listing up to 20 users

**Security impact:** An Author-role user could previously enumerate all site users with `edit_posts` capability by calling the endpoint with no search term, and could confirm email addresses via the `user_email` search column.

## Test plan
- [ ] `test_suggested_authors_returns_empty_for_short_search` — single-char search returns `[]`
- [ ] `test_suggested_authors_returns_empty_for_empty_search` — no search param returns `[]`
- [ ] `test_suggested_authors_does_not_search_by_email` — email-based search no longer matches
- [ ] `test_suggested_authors_returns_results_for_valid_search` — 2+ char searches still work
- [ ] Verify existing tests remain green

Generated with [Claude Code](https://claude.com/claude-code)