### PR TITLE
Validate user existence before adding as co-author

### DIFF
--- a/includes/class-map-co-authors.php
+++ b/includes/class-map-co-authors.php
@@ -71,6 +71,10 @@ class Co_Authors {
 			return false;
 		}
 
+		if ( ! get_userdata( $user_id ) ) {
+			return false;
+		}
+
 		// The post's original author never needs to be stored as a co-author.
 		if ( (int) $post->post_author === $user_id ) {
 			return true;

--- a/tests/Test_Co_Authors.php
+++ b/tests/Test_Co_Authors.php
@@ -30,6 +30,11 @@ class Test_Co_Authors extends WP_UnitTestCase {
 		$this->assertSame( array(), Co_Authors::get_co_authors( $this->post_id ) );
 	}
 
+	public function test_add_co_author_rejects_nonexistent_user(): void {
+		$this->assertFalse( Co_Authors::add_co_author( $this->post_id, 999999 ) );
+		$this->assertNotContains( 999999, Co_Authors::get_co_authors( $this->post_id ) );
+	}
+
 	public function test_add_co_author_returns_true(): void {
 		$this->assertTrue( Co_Authors::add_co_author( $this->post_id, $this->user_id ) );
 	}


### PR DESCRIPTION
## Summary
- `add_co_author()` now checks that the user ID refers to an existing user before storing it in post meta
- Returns `false` for nonexistent user IDs, consistent with the existing post validation
- Prevents stale or invalid user IDs from accumulating in the co-authors list

**Security impact:** Defensive measure preventing invalid data in post meta. The REST API endpoint already validates user existence separately, but the public `add_co_author()` method is also callable from other code paths (e.g., invite acceptance, preserve_previous_author hook).

## Test plan
- [ ] `test_add_co_author_rejects_nonexistent_user` — returns false and does not store invalid ID
- [ ] Verify existing tests remain green

Generated with [Claude Code](https://claude.com/claude-code)