### PR TITLE
Optimize CI: test full PHP matrix on push, 7.4+8.5 on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        # PRs test only the oldest and newest supported versions.
+        # Pushes to trunk/copilot branches test the full range.
+        php: ${{ github.event_name == 'push' && fromJSON('["7.4","8.0","8.1","8.2","8.3","8.4","8.5"]') || fromJSON('["7.4","8.5"]') }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Pushes to trunk/copilot branches continue testing all PHP versions (7.4-8.5)
- PRs only test PHP 7.4 and 8.5 (oldest + newest) to reduce CI time

## Test plan
- [ ] This PR should only run PHP 7.4 and 8.5 jobs
- [ ] After merge, push to trunk should run all PHP versions

Generated with [Claude Code](https://claude.com/claude-code)